### PR TITLE
Add deps for building SELinux policies

### DIFF
--- a/tasks/basedeps.yml
+++ b/tasks/basedeps.yml
@@ -21,6 +21,7 @@
     - libxml2-python
     - liquibase
     - make
+    - policycoreutils-devel
     - postgresql
     - postgresql-jdbc
     - postgresql-server

--- a/tasks/root.yml
+++ b/tasks/root.yml
@@ -87,6 +87,7 @@
     - 8443
     - 8080
     - 5005
+    - 8161
   when: firewalld_status.rc == 0
   tags:
     - candlepin


### PR DESCRIPTION
This is required in order to deploy artemis as a service via
the deploy script.