### PR TITLE
RPM install json_pure & remove system ruby update. 

### DIFF
--- a/tasks/basedeps.yml
+++ b/tasks/basedeps.yml
@@ -33,6 +33,7 @@
     - ruby-devel
     - rubygem-bundler
     - rubygem-qpid_proton
+    - rubygem-json_pure
     - rubygems
     - tomcat
     - wget

--- a/tasks/root.yml
+++ b/tasks/root.yml
@@ -93,22 +93,6 @@
     - candlepin
     - candlepin-root
 
-- name: Gem refreshing
-  command: gem update --system
-  tags:
-    - candlepin
-    - candlepin-root
-
-- name: Install gem dependencies
-  gem:
-    name: "{{item}}"
-    user_install: False
-  with_items:
-    - json_pure
-  tags:
-    - candlepin
-    - candlepin-root
-
 - name: Create postgresql user
   postgresql_user:
     name: candlepin


### PR DESCRIPTION
Use RPM packages instead of gem install for json_pure. 
Also remove the general update of system ruby gems. 

This prevents gem install problems on Centos. 