### PR TITLE
Use createrepo_c package. Packege createrepo is not maintained.

### DIFF
--- a/tasks/basedeps.yml
+++ b/tasks/basedeps.yml
@@ -37,7 +37,7 @@
       - wget
       - zlib
       - zlib-devel
-      - createrepo
+      - createrepo_c
       - rpm-build
       - rpm-sign
       - python-requests


### PR DESCRIPTION
Deploy script uses `createrepo_c` now. It is available in `createrepo_c` package. Binary createrepo was used, but this package is not maintained anymore.