### PR TITLE
Added when statements to ignore #7 due to breaking current automated …

### DIFF
--- a/tasks/root.yml
+++ b/tasks/root.yml
@@ -53,11 +53,13 @@
   set_fact:
     host_address: "{{hostvars['dev']['ansible_default_ipv4']['gateway']}}"
     net_address_and_mask: "{{hostvars['dev']['ansible_default_ipv4']['gateway']}}/{{hostvars['dev']['ansible_default_ipv4']['netmask']}}"
+  when: hostvars['dev'] is defined
 
 - name: Set postgresql to trust connections from VM host
   lineinfile:
     dest: /var/lib/pgsql/data/pg_hba.conf
     line: "host    all         all         {{host_address}}/{{net_address_and_mask | ipaddr('prefix')}}           trust"
+  when: hostvars['dev'] is defined
   tags:
     - candlepin
     - candlepin-root


### PR DESCRIPTION
…processes

This will skip setting the items from #7 unless the hostvar 'dev' is actually defined in an environment.
This is not the case with rhsm-ansible or our build processes, so #7 broke our automated and manual build processes.