### PR TITLE
Updated Java optional args for remote debugging

### DIFF
--- a/tasks/basedeps.yml
+++ b/tasks/basedeps.yml
@@ -49,6 +49,7 @@
       - rpm-sign
       - python-requests
       - expect
+      - java-1.8.0-openjdk-devel
       - java-11-openjdk-devel
     state: present
   tags:
@@ -63,3 +64,9 @@
     - candlepin-basedeps
     - candlepin
     - system_update
+
+- name: Set Java version (Default Java 11)
+  command: bash -c 'sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-*/bin/java'
+
+- name: Set Java compiler version (Default Java 11)
+  command: bash -c 'sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-11*/bin/javac'

--- a/tasks/root.yml
+++ b/tasks/root.yml
@@ -18,7 +18,7 @@
 - name: Add remote debugging config to tomcat
   lineinfile:
     dest: /etc/tomcat/tomcat.conf
-    line: "JAVA_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"
+    line: "JAVA_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,address=*:8000,server=y,suspend=n"
   tags:
     - candlepin
     - candlepin-root


### PR DESCRIPTION
Changes -
- Updated the Java Opts for remote debugging to support JDK 11.
- Added OpenJDK 8 dependency(To be backward compatible)
- Added config changes to set Java 11 as default environment. 