### PR TITLE
setting environment during candlepin deploy

### DIFF
--- a/tasks/common/cp_deploy.yml
+++ b/tasks/common/cp_deploy.yml
@@ -29,6 +29,8 @@
         cmd: "{{cp_deploy_script}} {{cp_deploy_args}}"
         chdir: "{{candlepin_home}}"
         warn: false
+      environment:
+        JAVA_HOME: "/usr/lib/jvm/java-11/"
       when:
         - candlepin_home_dir.stat.isdir
   vars:


### PR DESCRIPTION
During the CP deploy using this role I get: 
```
Liquibase update Failed: org/candlepin/liquibase/FixDuplicatePoolsLiquibaseWrapper has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

This seems to be because the env is in some weird state between java 8 and 11.  This could also possibly be fixed in the deploy script, but when I run deploy in a real shell manually I can't reproduce this error.