### PR TITLE
Fixed issues with the Candlepin role when run externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,6 @@ An example playbook for Vagrant use is as follows:
 ---
 - hosts: all
 
-  environment:
-    JAVA_HOME: /usr/lib/jvm/java
-
   roles:
     - role: candlepin
 
@@ -134,18 +131,11 @@ An example playbook for Vagrant use is as follows:
 
     cp_git_checkout: false
     cp_deploy: false
-
-    rvm1_rubies: ['ruby-2.4']
-    rvm1_user: "{{ candlepin_user }}"
-    rvm1_bundler_install: true
 ```
 
 The above playbook would provision the VM with PostgreSQL and MariaDB support, configure the user environment,
 and configure Tomcat for remote debugging and profiling. It would not check out the Candlepin repo, and,
 obviously, would not deploy it.
-
-Note that when using this role from Vagrant, the `rvm1_*` variables must be re-specified, even if unchanged,
-to ensure they are present when the rvm role is invoked.
 
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,3 @@ cp_deploy_args: '-gta'
 
 cp_yourkit_library: "/opt/yjp/bin/linux-x86-64/libyjpagent.so"
 cp_yourkit_agent_port: 35675
-
-rvm1_rubies: ['ruby-2.4']
-rvm1_user: "{{ candlepin_user }}"
-rvm1_bundler_install: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,4 +28,9 @@ galaxy_info:
     - entitlement
 
 dependencies:
-  - rvm.ruby
+  - role: rvm.ruby
+    vars:
+      rvm1_rubies:
+        - 'ruby-2.4'
+      rvm1_user: "{{ candlepin_user | default('candlepin') }}"
+      rvm1_bundler_install: true

--- a/tasks/common/cp_debugging.yml
+++ b/tasks/common/cp_debugging.yml
@@ -22,6 +22,8 @@
         state: enabled
         permanent: true
         offline: false
+      when:
+        - "'firewalld.service' in ansible_facts.services"
       tags:
         - system
         - candlepin
@@ -72,6 +74,8 @@
         state: enabled
         permanent: true
         offline: false
+      when:
+        - "'firewalld.service' in ansible_facts.services"
       tags:
         - system
         - candlepin

--- a/tasks/common/cp_deploy.yml
+++ b/tasks/common/cp_deploy.yml
@@ -31,6 +31,8 @@
         warn: false
       when:
         - candlepin_home_dir.stat.isdir
+  environment:
+    JAVA_HOME: "/usr/lib/jvm/java"
   vars:
     cp_deploy_script: "{{candlepin_home}}/bin/deployment/deploy"
   tags:

--- a/tasks/el7/el7_base_deps.yml
+++ b/tasks/el7/el7_base_deps.yml
@@ -82,6 +82,8 @@
     - 443
     - 8080    # Candlepin Tomcat server
     - 8443    # ^
+  when:
+    - "'firewalld.service' in ansible_facts.services"
   tags:
     - system
     - candlepin

--- a/tasks/el8/el8_base_deps.yml
+++ b/tasks/el8/el8_base_deps.yml
@@ -99,6 +99,8 @@
     - 443
     - 8080    # Candlepin Tomcat server
     - 8443    # ^
+  when:
+    - "'firewalld.service' in ansible_facts.services"
   tags:
     - system
     - candlepin

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: "Gather system facts"
+  service_facts:
+
 - import_tasks: el7/el7_tasks.yml
   when:
     - ansible_distribution == 'CentOS'


### PR DESCRIPTION
- Added the JAVA_HOME environment variable to the deploy task to
  ensure it is present even when the user environment isn't
  configured
- Moved the RVM variable declarations to the proper location on
  the dependency declaration
- Added a check to ensure firewalld actually exists on the system
  before attempting to run tasks reliant on it