### PR TITLE
Fixed distribution detection to support RHEL 7 and 8

### DIFF
--- a/tasks/common/user_env.yml
+++ b/tasks/common/user_env.yml
@@ -8,6 +8,7 @@
     regexp: "^export JAVA_HOME="
     line: "export JAVA_HOME=/usr/lib/jvm/java"
     state: present
+    create: true
   tags:
     - candlepin
     - user_env
@@ -25,6 +26,7 @@
 
       unset LS_COLORS
     state: present
+    create: true
   tags:
     - candlepin
     - user_env

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,27 @@
 ---
 - name: "Gather system facts"
   service_facts:
+    # intentionally left empty
+  tags:
+    - always
 
-- import_tasks: el7/el7_tasks.yml
+- name: "Include EL7 tasks"
+  include_tasks:
+    file: el7/el7_tasks.yml
   when:
-    - ansible_distribution == 'CentOS'
-    - ansible_distribution_major_version == '7'
+    - ansible_facts['distribution'] in ["CentOS", "RedHat"]
+    - ansible_facts['distribution_major_version'] == "7"
+  tags:
+    - always
 
-- import_tasks: el8/el8_tasks.yml
+- name: "Include EL8 tasks"
+  include_tasks:
+    file: el8/el8_tasks.yml
   when:
-    - ansible_distribution == 'CentOS'
-    - ansible_distribution_major_version == '8'
+    - ansible_facts['distribution'] in ["CentOS", "RedHat"]
+    - ansible_facts['distribution_major_version'] == "8"
+  tags:
+    - always
 
 - import_tasks: common/cp_debugging.yml
   when:


### PR DESCRIPTION
- Updated the distribution detection for the base el7 and el8
  tasks to also support RHEL
- Updated the tasks updating bashrc dot files to create the
  files if they're not present