### PR TITLE
Use `version` to specify which git branch to fetch

### DIFF
--- a/tasks/common/cp_setup.yml
+++ b/tasks/common/cp_setup.yml
@@ -5,7 +5,7 @@
 - name: "Checkout Candlepin Repo"
   git:
     repo: "{{cp_git_repo}}"
-    refspec: "{{cp_git_ref}}"
+    version: "{{cp_git_ref}}"
     dest: "{{candlepin_home}}"
     force: true
     clone: true


### PR DESCRIPTION
The right option for the `git` module of ansible to specify the branch
to fetch is `version`, not `refspec` (which is used to specify
additional refs to fetch).