### PR TITLE
Adding unit tests

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,12 @@
+# warn_list:
+#   - command-instead-of-shell
+#   - command-instead-of-module
+#   - no-changed-when
+
+skip_list:
+  - no-handler
+  - package-latest
+  - role-name
+  - command-instead-of-shell
+  - command-instead-of-module
+  - no-changed-when

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: ansible-galaxy install rvm.ruby
 
       - name: Run Molecule tests.
-        run: molecule test
+        run: molecule -v test
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+---
+name: CI
+'on':
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "30 4 * * 4"
+
+defaults:
+  run:
+    working-directory: 'ansible-role-candlepin'
+
+jobs:
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'ansible-role-candlepin'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install yamllint ansible-lint
+
+      - name: Lint code.
+        run: |
+          yamllint .
+          ansible-lint .
+
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - fedora35
+          - centos8
+          - centos7
+          # - quay.io/centos/centos:centos7
+          # - quay.io/centos/centos:stream8
+          # - quay.io/fedora/fedora:35
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'ansible-role-candlepin'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule[docker] docker
+
+      - name: Install galaxy requirements
+        run: ansible-galaxy install rvm.ruby
+
+      - name: Run Molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] docker
+        run: pip3 install ansible molecule[docker] docker molecule-containers
 
       - name: Install galaxy requirements
         run: ansible-galaxy install rvm.ruby

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,36 @@
+---
+# Based on ansible-lint config
+extends: default
+
+ignore: |
+  env/
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
 ansible-role-candlepin
 =========
+
 An Ansible role that installs and deploys Candlepin for development or testing purposes.
 
 This role is intended for use with newer Candlepin branches, but the resultant environment may still be used
 with older builds with some minor tweaks or configuration changes within the environment after provisioning.
 
-
-
 Requirements
 ------------
+
 Candlepin has many requirements for its developers. You will need a Fedora or CentOS box, or RHEL with EPEL
 enabled to use this role. It is recommmended that that box has a non-root user to run Candlepin on (see
 variables below).
 
-
 Dependencies
 ------------
+
 This role depends on the `rvm1.ruby` role for installing and configuring RVM. At the time of writing, Candlpin
 has a strict requirement on Ruby 2.4, which is installed and managed via RVM.
 
-
-
 Role Variables
 --------------
+
 There are a number of variables which enable various features and aspects of a developer environment. The
 primary flow control variables are the six boolean variables listed below:
 
@@ -36,14 +35,13 @@ primary flow control variables are the six boolean variables listed below:
 - `cp_git_checkout`: whether or not the Candlepin repo will be cloned via git; defaults to true
 - `cp_deploy`: whether or not Candlepin will be deployed after provisionining the system; defaults to true
 
-
 For some of these tasks, some operations may be modified or configured by changing further variables. A full
 list of variables which are intended to be modified on a per-environment basis can be found in the
 `defaults/main.yml` file.
 
-
 User Configuration
 ------------------
+
 By default, Candlepin will be cloned and deployed from the `devel` directory in the `candlepin` user's home
 directory, but this can be modified by changing the three Candlepin home or user variables listed below:
 
@@ -56,15 +54,15 @@ In many cases, this can be left as-is. However, in the case of a Vagrant deploym
 need to be changed accordingly. For example, in a typical Vagrant setup where the Candlepin repo is mapped in
 from the host, these variables might be configured as follows:
 
-```
+```yaml
   ansible_user: vagrant
   candlepin_user: vagrant
   candlepin_home: /vagrant
 ```
 
-
 Git Configuration
 -----------------
+
 This role can clone Candlepin directly from git rather than having to map or copy it onto the host. Three
 variables control whether or not this action is performed, and what repo and tag is cloned.
 
@@ -73,10 +71,9 @@ variables control whether or not this action is performed, and what repo and tag
   defaults to "https://github.com/candlepin/candlepin"
 - `cp_git_ref`: a git ref tag indicating the branch, tag, or reference to checkout; defaults to "master"
 
-
-
 Deploying Candlpin
 ------------------
+
 By default, this role will deploy Candlepin if the repo exists in the configured location. The deployment
 can be configured by passing args accepted by Candlepin's deployment tool. See the documentation associated
 with that tool for details on its parameters.
@@ -88,13 +85,13 @@ By default, Candlepin will be deployed in a way that drops and re-creates its da
 synthetic test data, and then regenerates the candlepin.conf with default settings for PostgreSQL support.
 To change this to use MySQL/MariaDB instead, add the `-m` argument to the variable:
 
-```
+```yaml
   cp_deploy_args: '-gtam'
 ```
 
-
 YourKit Configuration
 ---------------------
+
 If the `cp_configure_debugging` variable is set, this role will configure Tomcat for both remote debugging
 support, and, optionally, YourKit profiling support. To setup YourKit with this role, a Linux-compatible
 agent library must be present on the host at the location specified in the `cp_yourkit_library` variable. If
@@ -104,15 +101,15 @@ this value is not provided, or the library is not present at that location, the 
   "/opt/yjp/bin/linux-x86-64/libyjpagent.so"
 - `cp_yourkit_agent_port`: the port on which the agent should listen for profiling clients; defaults to 35675
 
-
-
 Vagrant Integration
 -------------------
+
 This role can be used with Vagrant to quickly spin up a VM with a fully prepared development environment. In
 such cases, it is heavily advised to set the `candlepin_user` variable accordingly, at minimum.
 
 An example playbook for Vagrant use is as follows:
-```
+
+```yaml
 ---
 - hosts: all
 
@@ -137,15 +134,28 @@ The above playbook would provision the VM with PostgreSQL and MariaDB support, c
 and configure Tomcat for remote debugging and profiling. It would not check out the Candlepin repo, and,
 obviously, would not deploy it.
 
+Unit Testing & Molecule
+-----------------------
 
+The unit tests will run on github actions; to run the unit tests locally you will need ansible, molecule and its drivers.
+
+To install molecule run the following.
+Replace `podman` with `docker` if that is your container manager:
+
+```sh
+pip3 install molecule molecule[podman] molecule-containers
+```
+
+You might also want ansible-lint with `pip3 install ansible-lint` or `yum install python3-ansible-lint`.
+To run unit tests simply run `molecule test`.  By default this will test on `fedora35`, or you can
+`export MOLECULE_DISTRO='centos8'` (or `centos7`) to change the test target.
 
 License
 -------
+
 GPLv2
-
-
 
 Author Information
 ------------------
-See [official documentation](http://www.candlepinproject.org).
 
+See [official documentation](http://www.candlepinproject.org).

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,8 @@ galaxy_info:
   description: "Candlepin Entitlement Management"
   company: "Red Hat"
   license: license (GPLv2)
-  min_ansible_version: 2.3
+  min_ansible_version: '2.4'
+  role_name: candlepin
 
   # look into doing this
   # min_ansible_container_version:
@@ -18,8 +19,8 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-      - 7
-      - 8
+      - '7'
+      - '8'
     - name: Fedora
       versions:
       - all
@@ -34,3 +35,5 @@ dependencies:
         - 'ruby-2.4'
       rvm1_user: "{{ candlepin_user | default('candlepin') }}"
       rvm1_bundler_install: true
+    tags:
+      - molecule-idempotence-notest

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,53 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  vars:
+    candlepin_user: "root"
+    candlepin_user_home: "/root/"
+    cp_configure_postgresql: false
+    cp_configure_mariadb: false
+    cp_configure_user_env: true
+    cp_configure_debugging: true
+    cp_git_checkout: true
+    cp_deploy: false
+    rvm1_install_flags: "--auto-dotfiles"
+    rvm1_install_path: "/usr/local/rvm"
+
+  tasks:
+    - name: Create initial user
+      ansible.builtin.user:
+        name: "candlepin"
+
+    - name: Install deps
+      ansible.builtin.package:
+        name:
+          - ca-certificates
+          - findutils
+          - procps-ng
+          - python3
+          - python3-libselinux
+          - selinux-policy
+          - which
+        state: present
+      when:
+        - ansible_distribution_major_version == '8' or ansible_distribution_major_version == '35'
+
+    - name: Install deps
+      ansible.builtin.package:
+        name:
+          - ca-certificates
+          - findutils
+          - procps-ng
+          - python3
+          - python3-libselinux
+          - libselinux-python
+          - selinux-policy
+          - which
+      when:
+        - ansible_distribution_major_version == '7'
+
+    - name: "Include ansible-role-candlepin"
+      ansible.builtin.include_role:
+        name: "ansible-role-candlepin"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -11,7 +11,7 @@
     cp_configure_user_env: true
     cp_configure_debugging: true
     cp_git_checkout: true
-    cp_deploy: false
+    cp_deploy: true
     rvm1_install_flags: "--auto-dotfiles"
     rvm1_install_path: "/usr/local/rvm"
 
@@ -25,6 +25,8 @@
         name:
           - ca-certificates
           - findutils
+          - hostname
+          - initscripts-service
           - procps-ng
           - python3
           - python3-libselinux

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,7 +7,7 @@
     candlepin_user: "root"
     candlepin_user_home: "/root/"
     cp_configure_postgresql: true
-    cp_configure_mariadb: false
+    cp_configure_mariadb: true
     cp_configure_user_env: true
     cp_configure_debugging: true
     cp_git_checkout: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -34,7 +34,22 @@
           - which
         state: present
       when:
-        - ansible_distribution_major_version == '8' or ansible_distribution_major_version == '35'
+        - ansible_distribution_major_version == '35'
+
+    - name: Install deps
+      ansible.builtin.package:
+        name:
+          - ca-certificates
+          - findutils
+          - hostname
+          - procps-ng
+          - python3
+          - python3-libselinux
+          - selinux-policy
+          - which
+        state: present
+      when:
+        - ansible_distribution_major_version == '8'
 
     - name: Install deps
       ansible.builtin.package:
@@ -44,6 +59,8 @@
           - procps-ng
           - python3
           - python3-libselinux
+          - python36-PyMySQL
+          - python3-psycopg2
           - libselinux-python
           - selinux-policy
           - which

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,7 +6,7 @@
   vars:
     candlepin_user: "root"
     candlepin_user_home: "/root/"
-    cp_configure_postgresql: false
+    cp_configure_postgresql: true
     cp_configure_mariadb: false
     cp_configure_user_env: true
     cp_configure_debugging: true
@@ -47,6 +47,18 @@
           - which
       when:
         - ansible_distribution_major_version == '7'
+
+    - name: Wait for systemd to complete initialization.
+      ansible.builtin.command: systemctl is-system-running
+      register: systemctl_status
+      until: >
+        'running' in systemctl_status.stdout or
+        'degraded' in systemctl_status.stdout
+      retries: 30
+      delay: 5
+      when: ansible_service_mgr == 'systemd'
+      changed_when: false
+      failed_when: systemctl_status.rc > 1
 
     - name: "Include ansible-role-candlepin"
       ansible.builtin.include_role:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+  # name: podman
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-fedora35}-ansible:latest"
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+# lint: |
+#   set -e
+#   yamllint .
+#   ansible-lint .

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -2,16 +2,11 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
-  # name: podman
+  name: containers
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-fedora35}-ansible:latest"
-    # command: /sbin/init
+    image: "docker.io/geerlingguy/docker-${MOLECULE_DISTRO:-fedora35}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    # tmpfs:
-    #   - /run
-    #   - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
@@ -20,6 +15,7 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
+# github will run the linter; uncomment to have molecule do it
 # lint: |
 #   set -e
 #   yamllint .

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,6 +7,14 @@ driver:
 platforms:
   - name: instance
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-fedora35}-ansible:latest"
+    # command: /sbin/init
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    # tmpfs:
+    #   - /run
+    #   - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,21 @@
+---
+# After role verifications
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+
+  tasks:
+  - name: Get candlepin status
+    uri:
+      url: https://localhost:8443/candlepin/status
+      method: GET
+    register: candlepin_status
+
+  - name: show status
+    debug:
+      var: candlepin_status.json
+
+  - name: Assert Candlepin has been deployed
+    ansible.builtin.assert:
+      that: "'version' in candlepin_status.json"

--- a/tasks/common/cp_debugging.yml
+++ b/tasks/common/cp_debugging.yml
@@ -3,7 +3,7 @@
   block:
     - name: "Create remote debugging configuration file for Tomcat"
       become: true
-      blockinfile:
+      ansible.builtin.blockinfile:
         path: "/etc/tomcat/conf.d/cp_remote_debugging.conf"
         block: |
           CATALINA_OPTS="${CATALINA_OPTS} -Xdebug -Xrunjdwp:transport=dt_socket,address=*:8000,server=y,suspend=n"
@@ -17,12 +17,13 @@
 
     - name: "Enable Tomcat debugging port in firewalld"
       become: true
-      firewalld:
+      ansible.posix.firewalld:
         port: "8000/tcp"
         state: enabled
         permanent: true
         offline: false
       when:
+        - "'services' in ansible_facts"
         - "'firewalld.service' in ansible_facts.services"
       tags:
         - system
@@ -33,8 +34,8 @@
   block:
     - name: "Create directory for YourKit profiling library"
       become: true
-      file:
-        path: "{{cp_yourkit_guest_home}}"
+      ansible.builtin.file:
+        path: "{{ cp_yourkit_guest_home }}"
         state: directory
         mode: 0755
         recurse: true
@@ -44,9 +45,9 @@
 
     - name: "Copy YourKit library file(s) from host"
       become: true
-      copy:
-        src: "{{cp_yourkit_library}}"
-        dest: "{{cp_yourkit_guest_library}}"
+      ansible.builtin.copy:
+        src: "{{ cp_yourkit_library }}"
+        dest: "{{ cp_yourkit_guest_library }}"
         mode: 0755
       tags:
         - candlepin
@@ -54,11 +55,11 @@
 
     - name: "Create YourKit profiling configuration file for Tomcat"
       become: true
-      blockinfile:
+      ansible.builtin.blockinfile:
         path: "/etc/tomcat/conf.d/cp_yourkit_profiling.conf"
         block: |
           export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/yjp/bin/linux-x86-64"
-          CATALINA_OPTS="${CATALINA_OPTS} -agentlib:yjpagent=port={{cp_yourkit_agent_port}}"
+          CATALINA_OPTS="${CATALINA_OPTS} -agentlib:yjpagent=port={{ cp_yourkit_agent_port }}"
         state: present
         create: true
         mode: 0755
@@ -69,12 +70,13 @@
 
     - name: "Enable YourKit ports in firewalld"
       become: true
-      firewalld:
-        port: "{{cp_yourkit_agent_port}}/tcp"
+      ansible.posix.firewalld:
+        port: "{{ cp_yourkit_agent_port }}/tcp"
         state: enabled
         permanent: true
         offline: false
       when:
+        - "'services' in ansible_facts"
         - "'firewalld.service' in ansible_facts.services"
       tags:
         - system
@@ -82,6 +84,6 @@
         - debugging
   vars:
     cp_yourkit_guest_home: "/opt/yjp/bin/linux-x86-64"
-    cp_yourkit_guest_library: "{{cp_yourkit_guest_home}}/libyjpagent.so"
+    cp_yourkit_guest_library: "{{ cp_yourkit_guest_home }}/libyjpagent.so"
   when:
     - cp_yourkit_library is file

--- a/tasks/common/cp_deploy.yml
+++ b/tasks/common/cp_deploy.yml
@@ -29,6 +29,7 @@
         cmd: "{{ cp_deploy_script }} {{ cp_deploy_args }}"
         chdir: "{{ candlepin_home }}"
         warn: false
+      changed_when: false
       when:
         - candlepin_home_dir.stat.isdir
   environment:

--- a/tasks/common/cp_deploy.yml
+++ b/tasks/common/cp_deploy.yml
@@ -6,35 +6,35 @@
 - name: "Deploy Candlepin"
   block:
     - name: "Ensure the Candlepin directory exists"
-      stat:
-        path: "{{candlepin_home}}"
+      ansible.builtin.stat:
+        path: "{{ candlepin_home }}"
       register: candlepin_home_dir
 
     - name: "Check for legacy Candlepin deploy script"
-      stat:
-        path: "{{candlepin_home}}/server/bin/deploy"
+      ansible.builtin.stat:
+        path: "{{ candlepin_home }}/server/bin/deploy"
       register: cp_deploy_script_file
       when:
         - candlepin_home_dir.stat.isdir
 
     - name: "Update Candlepin deploy script path to use legacy path"
-      set_fact:
-        cp_deploy_script: "{{candlepin_home}}/server/bin/deploy"
+      ansible.builtin.set_fact:
+        cp_deploy_script: "{{ candlepin_home }}/server/bin/deploy"
       when:
         - candlepin_home_dir.stat.isdir
         - cp_deploy_script_file.stat.exists
 
     - name: "Execute deploy script"
-      command:
-        cmd: "{{cp_deploy_script}} {{cp_deploy_args}}"
-        chdir: "{{candlepin_home}}"
+      ansible.builtin.command:
+        cmd: "{{ cp_deploy_script }} {{ cp_deploy_args }}"
+        chdir: "{{ candlepin_home }}"
         warn: false
       when:
         - candlepin_home_dir.stat.isdir
   environment:
     JAVA_HOME: "/usr/lib/jvm/java"
   vars:
-    cp_deploy_script: "{{candlepin_home}}/bin/deployment/deploy"
+    cp_deploy_script: "{{ candlepin_home }}/bin/deployment/deploy"
   tags:
     - candlepin
     - candlepin-deploy

--- a/tasks/common/cp_setup.yml
+++ b/tasks/common/cp_setup.yml
@@ -1,12 +1,12 @@
 # These tasks must be run as the candlepin user. main.yml imports this file with become_user set to
-# {{candlepin_user}}, but if these are included or imported anywhere else, that will likely need to
+# {{ candlepin_user }}, but if these are included or imported anywhere else, that will likely need to
 # be done there as well.
 ---
 - name: "Checkout Candlepin Repo"
-  git:
-    repo: "{{cp_git_repo}}"
-    version: "{{cp_git_ref}}"
-    dest: "{{candlepin_home}}"
+  ansible.builtin.git:
+    repo: "{{ cp_git_repo }}"
+    version: "{{ cp_git_ref }}"
+    dest: "{{ candlepin_home }}"
     force: true
     clone: true
   when:
@@ -17,8 +17,8 @@
 
 # Ensure Candlepin exists in a deployable state before attempting to run the bundle command
 - name: "Ensure the Candlepin directory exists"
-  stat:
-    path: "{{candlepin_home}}"
+  ansible.builtin.stat:
+    path: "{{ candlepin_home }}"
   register: candlepin_home_dir
   tags:
     - candlepin
@@ -27,12 +27,13 @@
 # Impl note:
 # This has to be done with a login shell to get the correct version of Ruby when using RVM
 - name: "Install Candlepin gem bundle"
-  shell: bash --login -c 'bundle install'
+  ansible.builtin.shell: bash --login -c 'bundle install'
   args:
-    chdir: "{{candlepin_home}}"
+    chdir: "{{ candlepin_home }}"
     warn: false
   when:
     - candlepin_home_dir.stat.exists and candlepin_home_dir.stat.isdir
+  changed_when: false
   tags:
     - candlepin
     - candlepin-setup

--- a/tasks/common/user_env.yml
+++ b/tasks/common/user_env.yml
@@ -1,21 +1,22 @@
 # These tasks must be run as the candlepin user. main.yml imports this file with become_user set to
-# {{candlepin_user}}, but if these are included or imported anywhere else, that will likely need to
+# {{ candlepin_user }}, but if these are included or imported anywhere else, that will likely need to
 # be done there as well.
 ---
 - name: "Add JAVA_HOME to .bashrc"
-  lineinfile:
-    path: "{{candlepin_user_home}}/.bashrc"
+  ansible.builtin.lineinfile:
+    path: "{{ candlepin_user_home }}/.bashrc"
     regexp: "^export JAVA_HOME="
     line: "export JAVA_HOME=/usr/lib/jvm/java"
     state: present
     create: true
+    mode: '0644'
   tags:
     - candlepin
     - user_env
 
 - name: "Set user prompt colors and features"
-  blockinfile:
-    path: "{{candlepin_user_home}}/.bash_profile"
+  ansible.builtin.blockinfile:
+    path: "{{ candlepin_user_home }}/.bash_profile"
     block: |
       parse_git_branch() {
         git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
@@ -27,6 +28,7 @@
       unset LS_COLORS
     state: present
     create: true
+    mode: "0644"
   tags:
     - candlepin
     - user_env
@@ -34,21 +36,22 @@
 - name: "Standardize location of Candlepin repo"
   block:
     - name: "Check for Vagrant Candlepin repo mapping"
-      stat:
-        path: "{{cp_vagrant_mapping}}"
+      ansible.builtin.stat:
+        path: "{{ cp_vagrant_mapping }}"
       register: cp_vagrant_mapping_file
 
     - name: "Create user-space devel directory"
-      file:
-        path: "{{candlepin_user_home}}/devel"
+      ansible.builtin.file:
+        path: "{{ candlepin_user_home }}/devel"
         state: directory
+        mode: "0755"
       when:
         - cp_vagrant_mapping_file.stat.exists
 
     - name: "Create devel symlink to Vagrant-mapped Candlepin repo"
-      file:
-        src: "{{cp_vagrant_mapping}}"
-        path: "{{candlepin_user_home}}/devel/candlepin"
+      ansible.builtin.file:
+        src: "{{ cp_vagrant_mapping }}"
+        path: "{{ candlepin_user_home }}/devel/candlepin"
         state: link
       when:
         - cp_vagrant_mapping_file.stat.exists

--- a/tasks/el7/el7_base_deps.yml
+++ b/tasks/el7/el7_base_deps.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Disable SELinux"
   become: true
-  selinux:
+  ansible.posix.selinux:
     state: disabled
   tags:
     - system
@@ -9,9 +9,10 @@
 
 - name: "Update system packages"
   become: true
-  package:
+  ansible.builtin.package:
     name: "*"
     state: latest
+  changed_when: false
   tags:
     - system
     - system_update
@@ -19,7 +20,7 @@
 
 - name: "Install Candlepin requirements"
   become: true
-  package:
+  ansible.builtin.package:
     name:
       - git
       - gcc
@@ -49,20 +50,22 @@
 # root permissions. Using become and the raw shell command invokes these in root's environment,
 # which will fail at best, or silently map the wrong command at worst.
 - name: "Configure alternatives: java"
-  shell: sh -c 'sudo alternatives --set java /usr/lib/jvm/java-11-openjdk-*/bin/java'
+  ansible.builtin.shell: sh -c 'sudo alternatives --set java /usr/lib/jvm/java-11-openjdk-*/bin/java'
+  changed_when: false
   tags:
     - base_deps
     - candlepin
 
 - name: "Configure alternatives: javac"
-  shell: sh -c 'sudo alternatives --set javac /usr/lib/jvm/java-11-openjdk-*/bin/javac'
+  ansible.builtin.shell: sh -c 'sudo alternatives --set javac /usr/lib/jvm/java-11-openjdk-*/bin/javac'
+  changed_when: false
   tags:
     - base_deps
     - candlepin
 
 - name: "Update Tomcat configuration to use Alternatives-configured Java"
   become: true
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /etc/tomcat/tomcat.conf
     regexp: "JAVA_HOME="
     line: "JAVA_HOME=\"/usr/lib/jvm/java\""
@@ -72,8 +75,8 @@
 
 - name: "Enable necessary ports in firewalld"
   become: true
-  firewalld:
-    port: "{{item}}/tcp"
+  ansible.posix.firewalld:
+    port: "{{ item }}/tcp"
     state: enabled
     permanent: true
     offline: false
@@ -83,6 +86,7 @@
     - 8080    # Candlepin Tomcat server
     - 8443    # ^
   when:
+    - "'services' in ansible_facts"
     - "'firewalld.service' in ansible_facts.services"
   tags:
     - system

--- a/tasks/el7/el7_mariadb.yml
+++ b/tasks/el7/el7_mariadb.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Install MariaDB packages"
   become: true
-  package:
+  ansible.builtin.package:
     name:
       - mariadb
       - mariadb-server
@@ -14,7 +14,7 @@
 
 - name: "Set Candlepin-specific MySQL configuration (collation-server)"
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/my.cnf.d/candlepin.cnf
     mode: '0644'
     section: mysqld
@@ -27,7 +27,7 @@
 
 - name: "Set Candlepin-specific MySQL configuration (character-set-server)"
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/my.cnf.d/candlepin.cnf
     mode: '0644'
     section: mysqld
@@ -40,7 +40,7 @@
 
 - name: "Set Candlepin-specific MySQL configuration (transaction-isolation)"
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/my.cnf.d/candlepin.cnf
     mode: '0644'
     section: mysqld
@@ -53,7 +53,7 @@
 
 - name: "Set Candlepin-specific MySQL configuration (default-time-zone)"
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/my.cnf.d/server.cnf
     section: server
     option: default-time-zone
@@ -65,7 +65,7 @@
 
 - name: "Enable and start the MariaDB service"
   become: true
-  service:
+  ansible.builtin.service:
     name: mariadb.service
     enabled: true
     state: started
@@ -75,7 +75,7 @@
 
 - name: "Create the 'candlepin' MariaDB user"
   become: true
-  mysql_user:
+  community.mysql.mysql_user:
     name: candlepin
     priv: "candlepin.*:ALL,GRANT"
     state: present
@@ -84,7 +84,7 @@
     - mariadb
 
 - name: "Create the 'candlepin' MariaDB database"
-  mysql_db:
+  community.mysql.mysql_db:
     login_user: candlepin
     name: candlepin
     state: present

--- a/tasks/el7/el7_postgresql.yml
+++ b/tasks/el7/el7_postgresql.yml
@@ -11,6 +11,7 @@
 - name: "Enable PostgreSQL 12 repository"
   become: true
   ansible.builtin.command: yum-config-manager --enable pgdg12
+  changed_when: false
   tags:
     - postgresql
     - candlepin

--- a/tasks/el7/el7_postgresql.yml
+++ b/tasks/el7/el7_postgresql.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Set up repository that includes PostgreSQL 12"
   become: true
-  yum:
+  ansible.builtin.yum:
     name: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     state: present
   tags:
@@ -10,14 +10,14 @@
 
 - name: "Enable PostgreSQL 12 repository"
   become: true
-  command: yum-config-manager --enable pgdg12
+  ansible.builtin.command: yum-config-manager --enable pgdg12
   tags:
     - postgresql
     - candlepin
 
 - name: "Install PostgreSQL packages"
   become: true
-  package:
+  ansible.builtin.package:
     name:
       - postgresql12-server
       - postgresql12
@@ -30,7 +30,7 @@
 
 - name: "Initialize PostgreSQL database"
   become: true
-  command:
+  ansible.builtin.command:
     cmd: postgresql-12-setup initdb
     creates: "/var/lib/pgsql/12/data/PG_VERSION"
     warn: false
@@ -40,7 +40,7 @@
 
 - name: "Configure PostgreSQL to trust local connections (1 of 3)"
   become: true
-  postgresql_pg_hba:
+  community.postgresql.postgresql_pg_hba:
     dest: /var/lib/pgsql/12/data/pg_hba.conf
     contype: local
     databases: all
@@ -54,7 +54,7 @@
 
 - name: "Configure PostgreSQL to trust local connections (2 of 3)"
   become: true
-  postgresql_pg_hba:
+  community.postgresql.postgresql_pg_hba:
     dest: /var/lib/pgsql/12/data/pg_hba.conf
     contype: host
     databases: all
@@ -69,7 +69,7 @@
 
 - name: "Configure PostgreSQL to trust local connections (3 of 3)"
   become: true
-  postgresql_pg_hba:
+  community.postgresql.postgresql_pg_hba:
     dest: /var/lib/pgsql/12/data/pg_hba.conf
     contype: host
     databases: all
@@ -84,7 +84,7 @@
 
 - name: "Enable and start the PostgreSQL service"
   become: true
-  service:
+  ansible.builtin.service:
     name: postgresql-12.service
     enabled: true
     state: started
@@ -93,7 +93,7 @@
     - candlepin
 
 - name: "Create the 'candlepin' PostgreSQL user"
-  postgresql_user:
+  community.postgresql.postgresql_user:
     name: candlepin
     password: candlepin
     role_attr_flags: CREATEDB
@@ -102,7 +102,7 @@
     - candlepin
 
 - name: "Create the 'candlepin' PostgreSQL database"
-  postgresql_db:
+  community.postgresql.postgresql_db:
     name: candlepin
     owner: candlepin
   tags:

--- a/tasks/el8/el8_base_deps.yml
+++ b/tasks/el8/el8_base_deps.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Disable SELinux"
   become: true
-  selinux:
+  ansible.posix.selinux:
     state: disabled
   tags:
     - system
@@ -10,9 +10,10 @@
 # FIXME: Update this task to use the dnf module once Ansible 2.10 or newer is readily available
 - name: "Update system packages"
   become: true
-  command:
+  ansible.builtin.command:
     cmd: dnf update -y --allowerasing
     warn: false
+  changed_when: false
   tags:
     - system
     - system_update
@@ -20,16 +21,17 @@
 
 - name: "Enable required DNF modules"
   become: true
-  command:
+  ansible.builtin.command:
     cmd: dnf module enable -y pki-core pki-deps
     warn: false
+  changed_when: false
   tags:
     - base_deps
     - candlepin
 
 - name: "Install Candlepin requirements"
   become: true
-  package:
+  ansible.builtin.package:
     name:
       - git
       - gcc
@@ -40,6 +42,7 @@
       - openssl
       - jss
       - pki-servlet-engine
+      - platform-python
       - python36
       - python3-libxml2
       - python3-requests
@@ -60,26 +63,29 @@
 # root permissions. Using become and the raw shell command invokes these in root's environment,
 # which will fail at best, or silently map the wrong command at worst.
 - name: "Configure alternatives: python"
-  shell: sh -c 'sudo alternatives --set python $(which python3)'
+  ansible.builtin.shell: sh -c 'sudo alternatives --set python /usr/bin/python3'
+  changed_when: false
   tags:
     - base_deps
     - candlepin
 
 - name: "Configure alternatives: java"
-  shell: sh -c 'sudo alternatives --set java /usr/lib/jvm/java-11-openjdk-*/bin/java'
+  ansible.builtin.shell: sh -c 'sudo alternatives --set java /usr/lib/jvm/java-11-openjdk-*/bin/java'
+  changed_when: false
   tags:
     - base_deps
     - candlepin
 
 - name: "Configure alternatives: javac"
-  shell: sh -c 'sudo alternatives --set javac /usr/lib/jvm/java-11-openjdk-*/bin/javac'
+  ansible.builtin.shell: sh -c 'sudo alternatives --set javac /usr/lib/jvm/java-11-openjdk-*/bin/javac'
+  changed_when: false
   tags:
     - base_deps
     - candlepin
 
 - name: "Update Tomcat configuration to use Alternatives-configured Java"
   become: true
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /etc/tomcat/tomcat.conf
     regexp: "JAVA_HOME="
     line: "JAVA_HOME=\"/usr/lib/jvm/java\""
@@ -89,8 +95,8 @@
 
 - name: "Enable necessary ports in firewalld"
   become: true
-  firewalld:
-    port: "{{item}}/tcp"
+  ansible.posix.firewalld:
+    port: "{{ item }}/tcp"
     state: enabled
     permanent: true
     offline: false
@@ -100,6 +106,7 @@
     - 8080    # Candlepin Tomcat server
     - 8443    # ^
   when:
+    - "'services' in ansible_facts"
     - "'firewalld.service' in ansible_facts.services"
   tags:
     - system

--- a/tasks/el8/el8_mariadb.yml
+++ b/tasks/el8/el8_mariadb.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Enable MariaDB DNF modules"
   become: true
-  command:
+  ansible.builtin.command:
     cmd: dnf module -y enable mariadb
     warn: false
   tags:
@@ -10,7 +10,7 @@
 
 - name: "Install MariaDB packages"
   become: true
-  package:
+  ansible.builtin.package:
     name:
       - mariadb
       - mariadb-server
@@ -23,7 +23,7 @@
 
 - name: "Set Candlepin-specific MySQL configuration (collation-server)"
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/my.cnf.d/candlepin.cnf
     mode: '0644'
     section: mysqld
@@ -74,7 +74,7 @@
 
 - name: "Enable and start the MariaDB service"
   become: true
-  service:
+  ansible.builtin.service:
     name: mariadb.service
     enabled: true
     state: started
@@ -84,7 +84,7 @@
 
 - name: "Create the 'candlepin' MariaDB user"
   become: true
-  mysql_user:
+  community.mysql.mysql_user:
     name: candlepin
     priv: "candlepin.*:ALL,GRANT"
     state: present
@@ -93,7 +93,7 @@
     - mariadb
 
 - name: "Create the 'candlepin' MariaDB database"
-  mysql_db:
+  community.mysql.mysql_db:
     login_user: candlepin
     name: candlepin
     state: present

--- a/tasks/el8/el8_mariadb.yml
+++ b/tasks/el8/el8_mariadb.yml
@@ -4,6 +4,7 @@
   ansible.builtin.command:
     cmd: dnf module -y enable mariadb
     warn: false
+  changed_when: false
   tags:
     - candlepin
     - mariadb

--- a/tasks/el8/el8_postgresql.yml
+++ b/tasks/el8/el8_postgresql.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Enable PostgreSQL DNF modules"
   become: true
-  command:
+  ansible.builtin.command:
     cmd: dnf module -y enable postgresql:12
     warn: false
   tags:
@@ -10,7 +10,7 @@
 
 - name: "Install PostgreSQL packages"
   become: true
-  package:
+  ansible.builtin.package:
     name:
       - postgresql-server
       - postgresql
@@ -23,7 +23,7 @@
 
 - name: "Initialize PostgreSQL database"
   become: true
-  command:
+  ansible.builtin.command:
     cmd: postgresql-setup --initdb --unit postgresql
     creates: "/var/lib/pgsql/data/PG_VERSION"
     warn: false
@@ -33,7 +33,7 @@
 
 - name: "Configure PostgreSQL to trust local connections (1 of 3)"
   become: true
-  postgresql_pg_hba:
+  community.postgresql.postgresql_pg_hba:
     dest: /var/lib/pgsql/data/pg_hba.conf
     contype: local
     databases: all
@@ -47,7 +47,7 @@
 
 - name: "Configure PostgreSQL to trust local connections (2 of 3)"
   become: true
-  postgresql_pg_hba:
+  community.postgresql.postgresql_pg_hba:
     dest: /var/lib/pgsql/data/pg_hba.conf
     contype: host
     databases: all
@@ -62,7 +62,7 @@
 
 - name: "Configure PostgreSQL to trust local connections (3 of 3)"
   become: true
-  postgresql_pg_hba:
+  community.postgresql.postgresql_pg_hba:
     dest: /var/lib/pgsql/data/pg_hba.conf
     contype: host
     databases: all
@@ -77,7 +77,7 @@
 
 - name: "Enable and start the PostgreSQL service"
   become: true
-  service:
+  ansible.builtin.service:
     name: postgresql.service
     enabled: true
     state: started
@@ -86,7 +86,7 @@
     - candlepin
 
 - name: "Create the 'candlepin' PostgreSQL user"
-  postgresql_user:
+  community.postgresql.postgresql_user:
     name: candlepin
     password: candlepin
     role_attr_flags: CREATEDB
@@ -95,7 +95,7 @@
     - candlepin
 
 - name: "Create the 'candlepin' PostgreSQL database"
-  postgresql_db:
+  community.postgresql.postgresql_db:
     name: candlepin
     owner: candlepin
   tags:

--- a/tasks/el8/el8_postgresql.yml
+++ b/tasks/el8/el8_postgresql.yml
@@ -4,6 +4,7 @@
   ansible.builtin.command:
     cmd: dnf module -y enable postgresql:12
     warn: false
+  changed_when: false
   tags:
     - postgresql
     - candlepin

--- a/tasks/f35/f35_base_deps.yml
+++ b/tasks/f35/f35_base_deps.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Disable SELinux"
   become: true
-  selinux:
+  ansible.posix.selinux:
     state: disabled
   tags:
     - system
@@ -10,9 +10,10 @@
 # FIXME: Update this task to use the dnf module once Ansible 2.10 or newer is readily available
 - name: "Update system packages"
   become: true
-  command:
+  ansible.builtin.command:
     cmd: dnf update -y --allowerasing
     warn: false
+  changed_when: false
   tags:
     - system
     - system_update
@@ -20,7 +21,7 @@
 
 - name: "Install Candlepin requirements"
   become: true
-  package:
+  ansible.builtin.package:
     name:
       - git
       - gcc
@@ -51,20 +52,22 @@
 # root permissions. Using become and the raw shell command invokes these in root's environment,
 # which will fail at best, or silently map the wrong command at worst.
 - name: "Configure alternatives: java"
-  shell: sh -c 'sudo alternatives --set java /usr/lib/jvm/java-11-openjdk-*/bin/java'
+  ansible.builtin.shell: sh -c 'sudo alternatives --set java /usr/lib/jvm/java-11-openjdk-*/bin/java'
+  changed_when: false
   tags:
     - base_deps
     - candlepin
 
 - name: "Configure alternatives: javac"
-  shell: sh -c 'sudo alternatives --set javac /usr/lib/jvm/java-11-openjdk-*/bin/javac'
+  ansible.builtin.shell: sh -c 'sudo alternatives --set javac /usr/lib/jvm/java-11-openjdk-*/bin/javac'
+  changed_when: false
   tags:
     - base_deps
     - candlepin
 
 - name: "Update Tomcat configuration to use Alternatives-configured Java"
   become: true
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /etc/tomcat/tomcat.conf
     regexp: "JAVA_HOME="
     line: "JAVA_HOME=\"/usr/lib/jvm/java\""
@@ -74,8 +77,8 @@
 
 - name: "Enable necessary ports in firewalld"
   become: true
-  firewalld:
-    port: "{{item}}/tcp"
+  ansible.posix.firewalld:
+    port: "{{ item }}/tcp"
     state: enabled
     permanent: true
     offline: false
@@ -85,6 +88,7 @@
     - 8080    # Candlepin Tomcat server
     - 8443    # ^
   when:
+    - "'services' in ansible_facts"
     - "'firewalld.service' in ansible_facts.services"
   tags:
     - system

--- a/tasks/f35/f35_mariadb.yml
+++ b/tasks/f35/f35_mariadb.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Install MariaDB packages"
   become: true
-  package:
+  ansible.builtin.package:
     name:
       - mariadb
       - mariadb-server
@@ -14,7 +14,7 @@
 
 - name: "Set Candlepin-specific MySQL configuration (collation-server)"
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/my.cnf.d/candlepin.cnf
     mode: '0644'
     section: mysqld
@@ -27,7 +27,7 @@
 
 - name: "Set Candlepin-specific MySQL configuration (character-set-server)"
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/my.cnf.d/candlepin.cnf
     mode: '0644'
     section: mysqld
@@ -40,7 +40,7 @@
 
 - name: "Set Candlepin-specific MySQL configuration (transaction-isolation)"
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/my.cnf.d/candlepin.cnf
     mode: '0644'
     section: mysqld
@@ -53,7 +53,7 @@
 
 - name: "Set Candlepin-specific MySQL configuration (default-time-zone)"
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/my.cnf.d/mariadb-server.cnf
     section: server
     option: default-time-zone
@@ -65,7 +65,7 @@
 
 - name: "Enable and start the MariaDB service"
   become: true
-  service:
+  ansible.builtin.service:
     name: mariadb.service
     enabled: true
     state: started
@@ -101,13 +101,13 @@
 
 - name: "Create the 'candlepin' MariaDB user"
   become: true
-  command: "mysql --user root --execute=\"CREATE USER 'candlepin'@'localhost'; GRANT ALL PRIVILEGES on candlepin.* TO 'candlepin'@'localhost' WITH GRANT OPTION;\""
+  ansible.builtin.command: "mysql --user root --execute=\"CREATE USER 'candlepin'@'localhost'; GRANT ALL PRIVILEGES on candlepin.* TO 'candlepin'@'localhost' WITH GRANT OPTION;\""
   tags:
     - candlepin
     - mariadb
 
 - name: "Create the 'candlepin' MariaDB database"
-  mysql_db:
+  community.mysql.mysql_db:
     login_user: candlepin
     name: candlepin
     state: present

--- a/tasks/f35/f35_mariadb.yml
+++ b/tasks/f35/f35_mariadb.yml
@@ -69,6 +69,7 @@
     name: mariadb.service
     enabled: true
     state: started
+  ignore_errors: "{{ ansible_check_mode }}"
   tags:
     - candlepin
     - mariadb
@@ -102,6 +103,7 @@
 - name: "Create the 'candlepin' MariaDB user"
   become: true
   ansible.builtin.command: "mysql --user root --execute=\"CREATE USER 'candlepin'@'localhost'; GRANT ALL PRIVILEGES on candlepin.* TO 'candlepin'@'localhost' WITH GRANT OPTION;\""
+  ignore_errors: "{{ ansible_check_mode }}"
   tags:
     - candlepin
     - mariadb
@@ -111,6 +113,7 @@
     login_user: candlepin
     name: candlepin
     state: present
+  ignore_errors: "{{ ansible_check_mode }}"
   tags:
     - candlepin
     - mariadb

--- a/tasks/f35/f35_mariadb.yml
+++ b/tasks/f35/f35_mariadb.yml
@@ -73,39 +73,13 @@
     - candlepin
     - mariadb
 
-# Impl note:
-# Newer versions of MariaDB/MySQL restrict the root user a bit more than previous, causing our old user
-# creation task to fail. We can work around this by reverting to the older authentication for the root
-# user, but that's more insecure than just isolating the jank to the single user creation task and
-# leaving the root account on the target system alone entirely.
-#
-# If this decision is ever flipped, the following tasks can be used to create the user with the mysql_user
-# task instead:
-#
-- name: "Allow insecure authentication for root"
+- name: "Create the 'candlepin' MariaDB user"
   become: true
-  ansible.builtin.command: "mysql -u root -e \"ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password;\""
+  ansible.builtin.command: "mysql --user root --execute=\"CREATE USER IF NOT EXISTS 'candlepin'@'localhost'; GRANT ALL PRIVILEGES on candlepin.* TO 'candlepin'@'localhost' WITH GRANT OPTION;\""
   changed_when: false
   tags:
     - candlepin
     - mariadb
-
-- name: "Create the 'candlepin' MariaDB user"
-  become: true
-  community.mysql.mysql_user:
-    name: candlepin
-    priv: "candlepin.*:ALL,GRANT"
-    state: present
-  tags:
-    - candlepin
-    - mariadb
-
-# - name: "Create the 'candlepin' MariaDB user"
-#   become: true
-#   ansible.builtin.command: "mysql --user root --execute=\"CREATE USER 'candlepin'@'localhost'; GRANT ALL PRIVILEGES on candlepin.* TO 'candlepin'@'localhost' WITH GRANT OPTION;\""
-#   tags:
-#     - candlepin
-#     - mariadb
 
 - name: "Create the 'candlepin' MariaDB database"
   community.mysql.mysql_db:

--- a/tasks/f35/f35_mariadb.yml
+++ b/tasks/f35/f35_mariadb.yml
@@ -69,7 +69,6 @@
     name: mariadb.service
     enabled: true
     state: started
-  ignore_errors: "{{ ansible_check_mode }}"
   tags:
     - candlepin
     - mariadb
@@ -83,37 +82,36 @@
 # If this decision is ever flipped, the following tasks can be used to create the user with the mysql_user
 # task instead:
 #
-# - name: "Allow insecure authentication for root"
-#   become: true
-#   command: "mysql -u root -e \"ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password;\""
-#   tags:
-#     - candlepin
-#     - mariadb
-#
-# - name: "Create the 'candlepin' MariaDB user"
-#   become: true
-#   mysql_user:
-#     name: candlepin
-#     priv: "candlepin.*:ALL,GRANT"
-#     state: present
-#   tags:
-#     - candlepin
-#     - mariadb
-
-- name: "Create the 'candlepin' MariaDB user"
+- name: "Allow insecure authentication for root"
   become: true
-  ansible.builtin.command: "mysql --user root --execute=\"CREATE USER 'candlepin'@'localhost'; GRANT ALL PRIVILEGES on candlepin.* TO 'candlepin'@'localhost' WITH GRANT OPTION;\""
-  ignore_errors: "{{ ansible_check_mode }}"
+  ansible.builtin.command: "mysql -u root -e \"ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password;\""
+  changed_when: false
   tags:
     - candlepin
     - mariadb
+
+- name: "Create the 'candlepin' MariaDB user"
+  become: true
+  community.mysql.mysql_user:
+    name: candlepin
+    priv: "candlepin.*:ALL,GRANT"
+    state: present
+  tags:
+    - candlepin
+    - mariadb
+
+# - name: "Create the 'candlepin' MariaDB user"
+#   become: true
+#   ansible.builtin.command: "mysql --user root --execute=\"CREATE USER 'candlepin'@'localhost'; GRANT ALL PRIVILEGES on candlepin.* TO 'candlepin'@'localhost' WITH GRANT OPTION;\""
+#   tags:
+#     - candlepin
+#     - mariadb
 
 - name: "Create the 'candlepin' MariaDB database"
   community.mysql.mysql_db:
     login_user: candlepin
     name: candlepin
     state: present
-  ignore_errors: "{{ ansible_check_mode }}"
   tags:
     - candlepin
     - mariadb

--- a/tasks/f35/f35_postgresql.yml
+++ b/tasks/f35/f35_postgresql.yml
@@ -15,7 +15,8 @@
 - name: "Initialize PostgreSQL database"
   become: true
   ansible.builtin.command:
-    cmd: postgresql-setup --initdb --unit postgresql
+    # cmd: postgresql-setup --initdb --unit postgresql
+    cmd: su - postgres -c "PGDATA=/var/lib/pgsql/data initdb"
     creates: "/var/lib/pgsql/data/PG_VERSION"
     warn: false
   tags:

--- a/tasks/f35/f35_postgresql.yml
+++ b/tasks/f35/f35_postgresql.yml
@@ -14,9 +14,9 @@
 
 - name: "Initialize PostgreSQL database"
   become: true
+  become_user: postgres
   ansible.builtin.command:
-    # cmd: postgresql-setup --initdb --unit postgresql
-    cmd: su - postgres -c "PGDATA=/var/lib/pgsql/data initdb"
+    cmd: pg_ctl initdb -D /var/lib/pgsql/data
     creates: "/var/lib/pgsql/data/PG_VERSION"
     warn: false
   tags:

--- a/tasks/f35/f35_postgresql.yml
+++ b/tasks/f35/f35_postgresql.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Install PostgreSQL packages"
   become: true
-  package:
+  ansible.builtin.package:
     name:
       - postgresql-server
       - postgresql
@@ -14,7 +14,7 @@
 
 - name: "Initialize PostgreSQL database"
   become: true
-  command:
+  ansible.builtin.command:
     cmd: postgresql-setup --initdb --unit postgresql
     creates: "/var/lib/pgsql/data/PG_VERSION"
     warn: false
@@ -24,7 +24,7 @@
 
 - name: "Configure PostgreSQL to trust local connections (1 of 3)"
   become: true
-  postgresql_pg_hba:
+  community.postgresql.postgresql_pg_hba:
     dest: /var/lib/pgsql/data/pg_hba.conf
     contype: local
     databases: all
@@ -38,7 +38,7 @@
 
 - name: "Configure PostgreSQL to trust local connections (2 of 3)"
   become: true
-  postgresql_pg_hba:
+  community.postgresql.postgresql_pg_hba:
     dest: /var/lib/pgsql/data/pg_hba.conf
     contype: host
     databases: all
@@ -53,7 +53,7 @@
 
 - name: "Configure PostgreSQL to trust local connections (3 of 3)"
   become: true
-  postgresql_pg_hba:
+  community.postgresql.postgresql_pg_hba:
     dest: /var/lib/pgsql/data/pg_hba.conf
     contype: host
     databases: all
@@ -68,7 +68,7 @@
 
 - name: "Enable and start the PostgreSQL service"
   become: true
-  service:
+  ansible.builtin.service:
     name: postgresql.service
     enabled: true
     state: started
@@ -77,7 +77,7 @@
     - candlepin
 
 - name: "Create the 'candlepin' PostgreSQL user"
-  postgresql_user:
+  community.postgresql.postgresql_user:
     name: candlepin
     password: candlepin
     role_attr_flags: CREATEDB
@@ -86,7 +86,7 @@
     - candlepin
 
 - name: "Create the 'candlepin' PostgreSQL database"
-  postgresql_db:
+  community.postgresql.postgresql_db:
     name: candlepin
     owner: candlepin
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: "Gather system facts"
-  service_facts:
+  ansible.builtin.service_facts:
     # intentionally left empty
   tags:
     - always
 
 - name: "Include EL7 tasks"
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: el7/el7_tasks.yml
   when:
     - ansible_facts['distribution'] in ["CentOS", "RedHat"]
@@ -15,7 +15,7 @@
     - always
 
 - name: "Include EL8 tasks"
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: el8/el8_tasks.yml
   when:
     - ansible_facts['distribution'] in ["CentOS", "RedHat"]
@@ -24,7 +24,7 @@
     - always
 
 - name: "Include F35+ tasks"
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: f35/f35_tasks.yml
   when:
     - ansible_facts['distribution'] == "Fedora"
@@ -32,21 +32,21 @@
   tags:
     - always
 
-- import_tasks: common/cp_debugging.yml
+- ansible.builtin.import_tasks: common/cp_debugging.yml
   when:
     - cp_configure_debugging | bool
 
-- import_tasks: common/cp_setup.yml
+- ansible.builtin.import_tasks: common/cp_setup.yml
   become: true
   become_user: "{{candlepin_user}}"
 
-- import_tasks: common/cp_deploy.yml
+- ansible.builtin.import_tasks: common/cp_deploy.yml
   become: true
   become_user: "{{candlepin_user}}"
   when:
     - cp_deploy | bool
 
-- import_tasks: common/user_env.yml
+- ansible.builtin.import_tasks: common/user_env.yml
   become: true
   become_user: "{{candlepin_user}}"
   when:


### PR DESCRIPTION
This PR adds some basic ansible unit tests; 

- This tests things by installing the role onto all 3 supported targets
- This also runs linters
-- spaces betwen brackets and vars
-- fully qualified module names
-- skipping other errors mostly so we don't have to change logic
-- generic yaml linting for formatting via yamllint
- All the tests happen on github and is externally viewable