### PR TITLE
Allow to disable the Ruby usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Dependencies
 This role depends on the `rvm1.ruby` role for installing and configuring RVM. At the time of writing, Candlpin
 has a strict requirement on Ruby 2.4, which is installed and managed via RVM.
 
+The dependency can be avoided by setting `cp_configure_ruby`, see the following section.
+
 Role Variables
 --------------
 
@@ -32,6 +34,7 @@ primary flow control variables are the six boolean variables listed below:
   be setup, such as bash prompts, colors, copying in SSH keys, etc.; defaults to false
 - `cp_configure_debugging`: controls whether or not Tomcat will be configured for remote debugging and
   profiling via YourKit; defaults to false
+- `cp_configure_ruby`: controls whether or not setup Ruby; defaults to true
 - `cp_git_checkout`: whether or not the Candlepin repo will be cloned via git; defaults to true
 - `cp_deploy`: whether or not Candlepin will be deployed after provisionining the system; defaults to true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ cp_configure_postgresql: true
 cp_configure_mariadb: true
 cp_configure_user_env: false
 cp_configure_debugging: false
+cp_configure_ruby: true
 
 cp_git_checkout: true
 cp_git_repo: "https://github.com/candlepin/candlepin"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -37,3 +37,5 @@ dependencies:
       rvm1_bundler_install: true
     tags:
       - molecule-idempotence-notest
+    when:
+      - cp_configure_ruby | bool

--- a/tasks/common/cp_setup.yml
+++ b/tasks/common/cp_setup.yml
@@ -32,6 +32,7 @@
     chdir: "{{ candlepin_home }}"
     warn: false
   when:
+    - cp_configure_ruby | bool
     - candlepin_home_dir.stat.exists and candlepin_home_dir.stat.isdir
   changed_when: false
   tags:


### PR DESCRIPTION
Introduce a new role variable "cp_configure_ruby" to disable the deployment of Ruby, skipping all the tasks related to that.

Ruby is needed only for running some of the tests, so deployments that need Candlepin only as a test environment can work fine without Ruby.