### PR TITLE
fedora: install python-unversioned-command

### DIFF
--- a/tasks/f35/f35_base_deps.yml
+++ b/tasks/f35/f35_base_deps.yml
@@ -35,6 +35,7 @@
       - python3
       - python3-libxml2
       - python3-requests
+      - python-unversioned-command
       - unzip
       - wget
       - zlib


### PR DESCRIPTION
There are many scripts in Candlepin that use "python" as Python interpreter. This was split in Fedora long ago to a separate "python-unversioned-command" package, so install it for now.