### PR TITLE
Support/fix Fedora 36

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -34,7 +34,8 @@
           - which
         state: present
       when:
-        - ansible_distribution_major_version == '35'
+        - ansible_distribution == "Fedora"
+        - ansible_distribution_major_version >= '35'
 
     - name: Install deps
       ansible.builtin.package:
@@ -49,6 +50,7 @@
           - which
         state: present
       when:
+        - ansible_distribution in ["CentOS", "RedHat"]
         - ansible_distribution_major_version == '8'
 
     - name: Install deps
@@ -65,6 +67,7 @@
           - selinux-policy
           - which
       when:
+        - ansible_distribution in ["CentOS", "RedHat"]
         - ansible_distribution_major_version == '7'
 
     - name: Wait for systemd to complete initialization.

--- a/tasks/common/cp_deploy.yml
+++ b/tasks/common/cp_deploy.yml
@@ -26,7 +26,7 @@
 
     - name: "Execute deploy script"
       ansible.builtin.command:
-        cmd: "{{ cp_deploy_script }} {{ cp_deploy_args }}"
+        cmd: "env QUIET=1 {{ cp_deploy_script }} {{ cp_deploy_args }}"
         chdir: "{{ candlepin_home }}"
         warn: false
       changed_when: false


### PR DESCRIPTION
- run the deploy script of Candlepin in quiet mode, so it does not try to use `notify-send` even if available (which apparently seems to be the case due to weak deps in f36+); `notify-send` cannot work anyway in the environment of the Ansible run
- fix some of the molecule bits that install dependencies for the molecule tests

See the explanation in each commit log for more details.