### PR TITLE
Drop "warn" from "command" & "shell" tasks

### DIFF
--- a/tasks/common/cp_deploy.yml
+++ b/tasks/common/cp_deploy.yml
@@ -28,7 +28,6 @@
       ansible.builtin.command:
         cmd: "env QUIET=1 {{ cp_deploy_script }} {{ cp_deploy_args }}"
         chdir: "{{ candlepin_home }}"
-        warn: false
       changed_when: false
       when:
         - candlepin_home_dir.stat.isdir

--- a/tasks/common/cp_setup.yml
+++ b/tasks/common/cp_setup.yml
@@ -30,7 +30,6 @@
   ansible.builtin.shell: bash --login -c 'bundle install'
   args:
     chdir: "{{ candlepin_home }}"
-    warn: false
   when:
     - cp_configure_ruby | bool
     - candlepin_home_dir.stat.exists and candlepin_home_dir.stat.isdir

--- a/tasks/el7/el7_postgresql.yml
+++ b/tasks/el7/el7_postgresql.yml
@@ -34,7 +34,6 @@
   ansible.builtin.command:
     cmd: postgresql-12-setup initdb
     creates: "/var/lib/pgsql/12/data/PG_VERSION"
-    warn: false
   tags:
     - postgresql
     - candlepin

--- a/tasks/el8/el8_base_deps.yml
+++ b/tasks/el8/el8_base_deps.yml
@@ -12,7 +12,6 @@
   become: true
   ansible.builtin.command:
     cmd: dnf update -y --allowerasing
-    warn: false
   changed_when: false
   tags:
     - system
@@ -23,7 +22,6 @@
   become: true
   ansible.builtin.command:
     cmd: dnf module enable -y pki-core pki-deps
-    warn: false
   changed_when: false
   tags:
     - base_deps

--- a/tasks/el8/el8_mariadb.yml
+++ b/tasks/el8/el8_mariadb.yml
@@ -3,7 +3,6 @@
   become: true
   ansible.builtin.command:
     cmd: dnf module -y enable mariadb
-    warn: false
   changed_when: false
   tags:
     - candlepin

--- a/tasks/el8/el8_postgresql.yml
+++ b/tasks/el8/el8_postgresql.yml
@@ -3,7 +3,6 @@
   become: true
   ansible.builtin.command:
     cmd: dnf module -y enable postgresql:12
-    warn: false
   changed_when: false
   tags:
     - postgresql
@@ -27,7 +26,6 @@
   ansible.builtin.command:
     cmd: postgresql-setup --initdb --unit postgresql
     creates: "/var/lib/pgsql/data/PG_VERSION"
-    warn: false
   tags:
     - postgresql
     - candlepin

--- a/tasks/f35/f35_base_deps.yml
+++ b/tasks/f35/f35_base_deps.yml
@@ -12,7 +12,6 @@
   become: true
   ansible.builtin.command:
     cmd: dnf update -y --allowerasing
-    warn: false
   changed_when: false
   tags:
     - system

--- a/tasks/f35/f35_postgresql.yml
+++ b/tasks/f35/f35_postgresql.yml
@@ -18,7 +18,6 @@
   ansible.builtin.command:
     cmd: pg_ctl initdb -D /var/lib/pgsql/data
     creates: "/var/lib/pgsql/data/PG_VERSION"
-    warn: false
   tags:
     - postgresql
     - candlepin


### PR DESCRIPTION
Added with commit 8e22ed52ff411425aaec05afe2dc00a0fc68c2b4 (i.e. the giant refactor), the "warn" attribute of "command" & "shell" tasks was supposed to silence the warnings from those tasks, mostly about using native modules instead of running commands manually.

Considering that Ansible Core 2.14 drops the "warn" attribute, and the only side effect seems to be only a couple of warnings, then stop using "warn" altogether, making the role usable also with Ansible Core 2.14.